### PR TITLE
feat: Convert examples 3, 4, and 6 to scenario format

### DIFF
--- a/mission/scenarios/converted_example_03/agents.yml
+++ b/mission/scenarios/converted_example_03/agents.yml
@@ -1,0 +1,37 @@
+# Agents and Controllers Definition
+agents:
+  # Sensor agent for the first reservoir
+  - id: sensor_agent_1
+    class: DigitalTwinAgent
+    config:
+      simulated_object_id: reservoir_1
+      state_topic: "state/reservoir_1"
+
+  # Sensor agent for the second reservoir
+  - id: sensor_agent_2
+    class: DigitalTwinAgent
+    config:
+      simulated_object_id: reservoir_2
+      state_topic: "state/reservoir_2"
+
+  # Inflow agents to provide a constant inflow to the reservoirs
+  - id: inflow_agent_1
+    class: ConstantInflowAgent
+    config:
+      target_component_id: reservoir_1
+      inflow_rate: 5.0 # m^3/s
+
+  - id: inflow_agent_2
+    class: ConstantInflowAgent
+    config:
+      target_component_id: reservoir_2
+      inflow_rate: 3.0 # m^3/s
+
+  # A central agent to aggregate data.
+  # This agent's logic is defined and registered in the run.py script.
+  - id: data_aggregator
+    class: DataAggregator
+    config:
+      subscribed_topics:
+        - "state/reservoir_1"
+        - "state/reservoir_2"

--- a/mission/scenarios/converted_example_03/components.yml
+++ b/mission/scenarios/converted_example_03/components.yml
@@ -1,0 +1,17 @@
+# Physical Components Definition
+components:
+  - id: reservoir_1
+    class: Reservoir
+    initial_state:
+      water_level: 50.0  # meters
+      volume: 50000.0    # m^3
+    parameters:
+      surface_area: 1000.0      # m^2
+
+  - id: reservoir_2
+    class: Reservoir
+    initial_state:
+      water_level: 40.0  # meters
+      volume: 32000.0    # m^3
+    parameters:
+      surface_area: 800.0       # m^2

--- a/mission/scenarios/converted_example_03/config.yml
+++ b/mission/scenarios/converted_example_03/config.yml
@@ -1,0 +1,4 @@
+# Simulation Configuration
+simulation:
+  duration: 100  # Simulation total time in seconds
+  dt: 1.0        # Simulation time step in seconds

--- a/mission/scenarios/converted_example_03/topology.yml
+++ b/mission/scenarios/converted_example_03/topology.yml
@@ -1,0 +1,3 @@
+# System Topology Definition
+# No physical connections in this scenario, so the list is empty.
+connections: []

--- a/mission/scenarios/converted_example_04/agents.yml
+++ b/mission/scenarios/converted_example_04/agents.yml
@@ -1,0 +1,24 @@
+# Agents and Controllers Definition
+agents:
+  # Agent to provide a constant inflow to the reservoir
+  - id: inflow_agent
+    class: ConstantInflowAgent
+    config:
+      target_component_id: main_reservoir
+      inflow_rate: 150.0 # m^3/s
+
+  # "Sensor" agent that perceives the state of the reservoir
+  - id: reservoir_twin
+    class: DigitalTwinAgent
+    config:
+      simulated_object_id: main_reservoir
+      state_topic: "state/reservoir/main"
+
+  # Custom control agent for the gate
+  - id: gate_controller
+    class: LocalGateControlAgent
+    config:
+      subscribed_topic: "state/reservoir/main"
+      target_gate_id: "flood_gate"
+      setpoint: 50.1 # meters
+      action_topic: "action/gate/flood_gate"

--- a/mission/scenarios/converted_example_04/components.yml
+++ b/mission/scenarios/converted_example_04/components.yml
@@ -1,0 +1,17 @@
+# Physical Components Definition
+components:
+  - id: main_reservoir
+    class: Reservoir
+    initial_state:
+      water_level: 50.0   # meters
+      volume: 500000.0    # m^3
+    parameters:
+      surface_area: 10000.0 # m^2
+
+  - id: flood_gate
+    class: Gate
+    initial_state:
+      opening: 0.0      # Start with the gate closed
+    parameters:
+      width: 5.0
+      discharge_coefficient: 0.8

--- a/mission/scenarios/converted_example_04/config.yml
+++ b/mission/scenarios/converted_example_04/config.yml
@@ -1,0 +1,4 @@
+# Simulation Configuration
+simulation:
+  duration: 400  # Simulation total time in seconds
+  dt: 1.0        # Simulation time step in seconds

--- a/mission/scenarios/converted_example_04/topology.yml
+++ b/mission/scenarios/converted_example_04/topology.yml
@@ -1,0 +1,4 @@
+# System Topology Definition
+connections:
+  - upstream: main_reservoir
+    downstream: flood_gate

--- a/mission/scenarios/converted_example_06/agents.yml
+++ b/mission/scenarios/converted_example_06/agents.yml
@@ -1,0 +1,63 @@
+# Agents and Controllers Definition
+agents:
+  # --- Inflow Agents ---
+  - id: inflow_agent_A
+    class: ConstantInflowAgent
+    config:
+      target_component_id: reservoir_A
+      inflow_rate: 100.0
+
+  - id: inflow_agent_B
+    class: ConstantInflowAgent
+    config:
+      target_component_id: reservoir_B
+      inflow_rate: 100.0
+
+  # --- Perception Agents ---
+  - id: twin_A
+    class: DigitalTwinAgent
+    config:
+      simulated_object_id: reservoir_A
+      state_topic: "state/reservoir/A"
+
+  - id: twin_B
+    class: DigitalTwinAgent
+    config:
+      simulated_object_id: reservoir_B
+      state_topic: "state/reservoir/B"
+
+  # --- Local Control Agents ---
+  - id: controller_A
+    class: LocalGateControlAgent
+    config:
+      state_subscription_topic: "state/reservoir/A"
+      action_topic: "action/gate/gate_A"
+      shutdown_topic: "command/shutdown/A"
+      initial_setpoint: 51.0
+
+  - id: controller_B
+    class: LocalGateControlAgent
+    config:
+      state_subscription_topic: "state/reservoir/B"
+      command_subscription_topic: "command/setpoint/B"
+      action_topic: "action/gate/gate_B"
+      initial_setpoint: 51.0
+
+  # --- Supervisory and Special Agents ---
+  - id: failure_injector
+    class: FailureInjectionAgent
+    config:
+      target_topic: "command/shutdown/A"
+      failure_time: 150.0
+
+  - id: supervisor
+    class: SupervisoryAgent
+    config:
+      # Topics to monitor
+      state_topic_A: "state/reservoir/A"
+      state_topic_B: "state/reservoir/B"
+      # Topic to send corrective commands on
+      command_topic_B: "command/setpoint/B"
+      # Thresholds for intervention
+      deviation_threshold: 1.0 # meters
+      corrective_setpoint: 50.2 # meters

--- a/mission/scenarios/converted_example_06/components.yml
+++ b/mission/scenarios/converted_example_06/components.yml
@@ -1,0 +1,33 @@
+# Physical Components Definition
+components:
+  - id: reservoir_A
+    class: Reservoir
+    initial_state:
+      water_level: 50.0
+      volume: 500000.0
+    parameters:
+      surface_area: 10000.0
+
+  - id: gate_A
+    class: Gate
+    initial_state:
+      opening: 0.0
+    parameters:
+      width: 5.0
+      discharge_coefficient: 0.8
+
+  - id: reservoir_B
+    class: Reservoir
+    initial_state:
+      water_level: 50.0
+      volume: 500000.0
+    parameters:
+      surface_area: 10000.0
+
+  - id: gate_B
+    class: Gate
+    initial_state:
+      opening: 0.0
+    parameters:
+      width: 5.0
+      discharge_coefficient: 0.8

--- a/mission/scenarios/converted_example_06/config.yml
+++ b/mission/scenarios/converted_example_06/config.yml
@@ -1,0 +1,4 @@
+# Simulation Configuration
+simulation:
+  duration: 500  # Simulation total time in seconds
+  dt: 1.0        # Simulation time step in seconds

--- a/mission/scenarios/converted_example_06/topology.yml
+++ b/mission/scenarios/converted_example_06/topology.yml
@@ -1,0 +1,6 @@
+# System Topology Definition
+connections:
+  - upstream: reservoir_A
+    downstream: gate_A
+  - upstream: reservoir_B
+    downstream: gate_B


### PR DESCRIPTION
This commit converts examples 3, 4, and 6 from the `docs/examples` directory into the YAML-based scenario format in `mission/scenarios`.

The following changes were made:
- Created `mission/scenarios/converted_example_03` and copied the YAML configuration files from `docs/examples/03_distributed_data_collection`.
- Created `mission/scenarios/converted_example_04` and copied the YAML configuration files from `docs/examples/04_distributed_decision_making`.
- Created `mission/scenarios/converted_example_06` and copied the YAML configuration files from `docs/examples/06_fault_tolerance`.